### PR TITLE
CLOUD-667: add call to registry to associate template_name to his own id

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If client authentication is set on the controller, use `--client-cert` and `--cl
 Metric name | Description
 ---- | ----------
 anka_instance_state_count | Count of Instances in a particular State (label: state)
-anka_instance_state_per_template_count | Count of Instances in a particular state, per Template (label: state, template_name, template_uuid)
+anka_instance_state_per_template_count | Count of Instances in a particular state, per Template (label: state, template_uuid, template_name)
 anka_instance_state_per_group_count | Count of Instances in a particular state, per Group (label: state, group_name)
 -- | --
 anka_node_instance_count | Count of Instances running on the Node

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If client authentication is set on the controller, use `--client-cert` and `--cl
 Metric name | Description
 ---- | ----------
 anka_instance_state_count | Count of Instances in a particular State (label: state)
-anka_instance_state_per_template_count | Count of Instances in a particular state, per Template (label: state, template_name)
+anka_instance_state_per_template_count | Count of Instances in a particular state, per Template (label: state, template_name, template_uuid)
 anka_instance_state_per_group_count | Count of Instances in a particular state, per Group (label: state, group_name)
 -- | --
 anka_node_instance_count | Count of Instances running on the Node

--- a/src/client/communicator.go
+++ b/src/client/communicator.go
@@ -64,7 +64,16 @@ func (this *Communicator) GetVmsData() (interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting vms data error: %s", err)
 	}
-	return d, nil
+	s, err := this.GetRegistryVms()
+	if err != nil {
+		return nil, fmt.Errorf("getting vms registry data error: %s", err)
+	}
+	m := d.([]types.Instance)
+	for k, v := range m {
+		i := v.Vm.TemplateUUID
+		m[k].Vm.TemplateNAME = s[i]
+	}
+	return m, nil
 }
 
 func (this *Communicator) GetRegistryData() (interface{}, error) {
@@ -75,6 +84,21 @@ func (this *Communicator) GetRegistryData() (interface{}, error) {
 		return nil, fmt.Errorf("getting registry data error: %s", err)
 	}
 	return d, nil
+}
+
+func (this *Communicator) GetRegistryVms() (map[string]string, error) {
+	endpoint := "/api/v1/registry/vm"
+	resp := &types.RegistryVmResponse{}
+	d, err := this.getData(endpoint, resp)
+	if err != nil {
+		return nil, fmt.Errorf("getting registry vms error: %s", err)
+	}
+	m := d.([]types.Vms)
+	VmsData := make(map[string]string)
+	for _, v := range m {
+		VmsData[v.VmID] = v.TemplateNAME
+	}
+	return VmsData, nil
 }
 
 func (this *Communicator) getData(endpoint string, repsObject types.Response) (interface{}, error) {

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -57,8 +57,15 @@ type Instance struct {
 type VmData struct {
 	State        string `json:"instance_state"`
 	TemplateUUID string `json:"vmid"`
+	TemplateNAME string `json:"name"` 
 	GroupUUID    string `json:"group_id"`
 	NodeUUID     string `json:"node_id"`
+}
+
+type Vms struct {
+	TemplateNAME   string `json:"name"`
+	VmID		   string `json:"id"`
+	Size           int64  `json:"size"`
 }
 
 type Response interface {
@@ -97,6 +104,16 @@ type RegistryResponse struct {
 func (this *RegistryResponse) GetBody() interface{} {
 	return this.Body
 }
+
+type RegistryVmResponse struct {
+	DefaultResponse
+	Body []Vms `json:"body,omtiempty"`
+}
+
+func (this *RegistryVmResponse) GetBody() interface{} {
+	return this.Body
+}
+
 
 type InstancesResponse struct {
 	DefaultResponse


### PR DESCRIPTION
## Pull Request 
This is a proposition for adding the feature to have the template name (more human readable at a glance) added in the same metrics.
Basically I add new types:
- `type Vms struct ` , hosts a map between template uuid and name.
- `type RegistryVmResponse struct`, will contain the response from `/registry/vm`.

Add and modify `communicator.go`
- `GetRegistryVms()`, keep updated the template list.
- enhanced ` GetVmsData() ` to add template name from the function above. 

Finally add feature in the publisher itself `instance_state_per.go`

Results:
```
curl localhost:22222/metrics
# TYPE anka_instance_state_per_template_count gauge
anka_instance_state_per_template_count{state="Error",template_name="anka-worker-bigsur/master-3",template_uuid="a60c626e-3e7e-4976-ba29-1f8334bc9fa9"} 0
anka_instance_state_per_template_count{state="Error",template_name="anka-worker-catalina/master-31",template_uuid="80c08f60-6125-4823-9180-a9829be8bfcc"} 0
anka_instance_state_per_template_count{state="Error",template_name="anka-worker-tester-bigsur/master-2",template_uuid="b0a9c20e-08b7-49ce-98fa-c7c26e1ecafa"} 0
........
```
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other: (describe here) 
  
## Proposed Change
<!-- Explain your change, its motivation, compare previous and new behaviour and link to issue, if exists -->
Issue Number: #7 

<!-- Write your answer here -->

## Breaking Change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications here -->

## Checklist

Please validate that your PR fulfills the following requirements:
- [x] I have read the **CONTRIBUTING.md** documentation
- [x] I have branched from the master branch
- [x] I have checked that a similar PR does not exist or has been rejected in the past
- [x] PR changes are specific to a feature or bug
- [x] No style/format/cosmetic changes included
- [x] I have used existing style and naming patterns in my changes
- [ ] Tests for the changes have been added/updated (if relevant)
- [x] Built/compiled and tested locally
- [x] Docs have been added/updated (if relevant)
- [x] I have squashed my changes into a single commit


## Additional Information
<!-- Any other information that is important to this PR such as screenshots of how the feature/bug looked before and after the change. -->