### PR TITLE
feat: annotate node and instance states with architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ For self signed certificates, you can either use `--skip-tls-verification` or pr
 
 Metric name | Description
 ---- | ----------
-anka_instance_state_count | Count of Instances in a particular State (label: state)
+anka_instance_state_count | Count of Instances in a particular State (label: arch, state)
 anka_instance_state_per_template_count | Count of Instances in a particular state, per Template (label: state, template_uuid, template_name)
 anka_instance_state_per_group_count | Count of Instances in a particular state, per Group (label: state, group_name)
 -- | --
 anka_node_instance_count | Count of Instances running on the Node
 anka_node_instance_capacity | Total Instance slots (capacity) on the Node
 anka_node_states | Node state (1 = current state) (label: id, name, state)
-anka_node_states_count | Count of Nodes in a particular state (label: state)
+anka_node_states_count | Count of Nodes in a particular state (label: arch, state)
 anka_node_disk_free_space | Amount of free disk space on the Node in Bytes
 anka_node_disk_total_space | Amount of total available disk space on the Node in Bytes
 anka_node_disk_anka_used_space | Amount of disk space used by Anka on the Node in Bytes

--- a/src/metrics/node_states.go
+++ b/src/metrics/node_states.go
@@ -33,16 +33,18 @@ func (nsm NodeStatesMetric) GetEventHandler() func(interface{}) error {
 var ankaNodeStatesMetrics = []NodeStatesMetric{
 	{
 		BaseAnkaMetric: BaseAnkaMetric{
-			metric: CreateGaugeMetricVec("anka_node_states_count", "Count of Nodes in a particular State (label: state)", []string{"state"}),
+			metric: CreateGaugeMetricVec("anka_node_states_count", "Count of Nodes in a particular State (label: arch, state)", []string{"arch", "state"}),
 			event:  events.EVENT_NODE_UPDATED,
 		},
 		HandleData: func(nodes []types.Node, metric *prometheus.GaugeVec) {
-			var stateIntMap = intMapFromStringSlice(types.NodeStates)
+			var archStateMap = intMapFromTwoStringSlices(types.Architectures, types.NodeStates)
 			for _, node := range nodes {
-				stateIntMap[node.State] = stateIntMap[node.State] + 1
+				archStateMap[node.HostArch][node.State] = archStateMap[node.HostArch][node.State] + 1
 			}
-			for _, state := range types.NodeStates {
-				metric.With(prometheus.Labels{"state": state}).Set(float64(stateIntMap[state]))
+			for _, arch := range types.Architectures {
+				for _, state := range types.NodeStates {
+					metric.With(prometheus.Labels{"arch": arch, "state": state}).Set(float64(archStateMap[arch][state]))
+				}
 			}
 		},
 	},

--- a/src/metrics/utils.go
+++ b/src/metrics/utils.go
@@ -10,12 +10,15 @@ import (
 	"github.com/veertuinc/anka-prometheus-exporter/src/types"
 )
 
-func intMapFromStringSlice(stringSlice []string) map[string]int {
-	intMap := map[string]int{}
-	for _, item := range stringSlice {
-		intMap[item] = 0
+func intMapFromTwoStringSlices(outerStringSlice []string, innerStringSlice []string) map[string]map[string]int {
+	outerMap := map[string]map[string]int{}
+	for _, outerItem := range outerStringSlice {
+		outerMap[outerItem] = map[string]int{}
+		for _, innerItem := range innerStringSlice {
+			outerMap[outerItem][innerItem] = 0
+		}
 	}
-	return intMap
+	return outerMap
 }
 
 func uniqueThisStringArray(arr []string) []string {

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -7,6 +7,11 @@ var NodeStates = []string{
 	"Updating",
 }
 
+var Architectures = []string{
+	"amd64",
+	"arm64",
+}
+
 var InstanceStates = []string{
 	"Scheduling",
 	"Pulling",
@@ -34,6 +39,7 @@ type Node struct {
 	DiskSize       uint        `json:"disk_size"`
 	State          string      `json:"state"`
 	Capacity       uint        `json:"capacity"`
+	HostArch       string      `json:"host_arch"`
 	Groups         []NodeGroup `json:"groups"`
 }
 
@@ -60,6 +66,7 @@ type VmData struct {
 	TemplateName string
 	GroupUUID    string `json:"group_id"`
 	NodeUUID     string `json:"node_id"`
+	Arch         string `json:"arch"`
 }
 
 type Response interface {


### PR DESCRIPTION
## Pull Request 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other: (describe here) 
  
## Proposed Change

For both: the instance as well as the node states it would be nice to see how the numbers affect the two different CPU architectures.

## Breaking Change?

- [x] Yes
- [ ] No

The querying tools should sum up the per-architecture numbers. But I'm unsure if all of them actually do.

## Checklist

Please validate that your PR fulfills the following requirements:
- [x] I have read the **CONTRIBUTING.md** documentation (if available)
- [x] I have branched from the default repo branch (can be master, main, or release/vX.X)
- [x] I have checked that a similar PR does not exist or has been rejected in the past
- [x] PR changes are specific to a feature or bug
- [x] No style/format/cosmetic changes included
- [x] I have used existing style and naming patterns in my changes
- [ ] Tests for the changes have been added/updated (if relevant)
- [x] Built/compiled and tested locally
- [x] Docs have been added/updated (if relevant)
- [x] I have squashed my changes into a single commit


## Additional Information

Node States:
```
# HELP anka_node_states_count Count of Nodes in a particular State (label: arch, state)
# TYPE anka_node_states_count gauge
anka_node_states_count{arch="amd64",state="Active"} 2
anka_node_states_count{arch="amd64",state="Inactive (Invalid License)"} 0
anka_node_states_count{arch="amd64",state="Offline"} 0
anka_node_states_count{arch="amd64",state="Updating"} 0
anka_node_states_count{arch="arm64",state="Active"} 3
anka_node_states_count{arch="arm64",state="Inactive (Invalid License)"} 0
anka_node_states_count{arch="arm64",state="Offline"} 0
anka_node_states_count{arch="arm64",state="Updating"} 0
```

Instance States:
```
# HELP anka_instance_state_count Count of Instances in a particular State (label: arch, state)
# TYPE anka_instance_state_count gauge
anka_instance_state_count{arch="amd64",state="Error"} 0
anka_instance_state_count{arch="amd64",state="Pulling"} 1
anka_instance_state_count{arch="amd64",state="Pushing"} 0
anka_instance_state_count{arch="amd64",state="Scheduling"} 1
anka_instance_state_count{arch="amd64",state="Started"} 2
anka_instance_state_count{arch="amd64",state="Stopped"} 0
anka_instance_state_count{arch="amd64",state="Stopping"} 0
anka_instance_state_count{arch="amd64",state="Terminated"} 0
anka_instance_state_count{arch="amd64",state="Terminating"} 0
anka_instance_state_count{arch="arm64",state="Error"} 0
anka_instance_state_count{arch="arm64",state="Pulling"} 0
anka_instance_state_count{arch="arm64",state="Pushing"} 0
anka_instance_state_count{arch="arm64",state="Scheduling"} 0
anka_instance_state_count{arch="arm64",state="Started"} 3
anka_instance_state_count{arch="arm64",state="Stopped"} 0
anka_instance_state_count{arch="arm64",state="Stopping"} 0
anka_instance_state_count{arch="arm64",state="Terminated"} 0
anka_instance_state_count{arch="arm64",state="Terminating"} 0
```

