### PR TITLE
feat: add missing drain mode state

### DIFF
--- a/src/types/types.go
+++ b/src/types/types.go
@@ -5,6 +5,7 @@ var NodeStates = []string{
 	"Inactive (Invalid License)",
 	"Active",
 	"Updating",
+	"Drain Mode",
 }
 
 var Architectures = []string{


### PR DESCRIPTION
## Pull Request 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other: (describe here) 
  
## Proposed Change

The "Drain Mode" instance state was missing in the exposed mappings

## Breaking Change?

- [ ] Yes
- [x] No

## Sample Output

```
# HELP anka_node_states_count Count of Nodes in a particular State, per Architecture (label: arch, state)
# TYPE anka_node_states_count gauge
anka_node_states_count{arch="amd64",state="Active"} 2
anka_node_states_count{arch="amd64",state="Drain Mode"} 1
anka_node_states_count{arch="amd64",state="Inactive (Invalid License)"} 0
anka_node_states_count{arch="amd64",state="Offline"} 0
anka_node_states_count{arch="amd64",state="Updating"} 0
anka_node_states_count{arch="arm64",state="Active"} 3
anka_node_states_count{arch="arm64",state="Drain Mode"} 1
anka_node_states_count{arch="arm64",state="Inactive (Invalid License)"} 0
anka_node_states_count{arch="arm64",state="Offline"} 0
anka_node_states_count{arch="arm64",state="Updating"} 0
```

## Additional Information

The [grafana dashboard](https://github.com/veertuinc/anka-build-cloud-grafana-dashboard) would benefit from an update for this.